### PR TITLE
Improve error handling

### DIFF
--- a/wp-rest-blocks.php
+++ b/wp-rest-blocks.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Plugin Name:       REST API blocks
+ * Plugin Name:       REST API Blocks
  * Plugin URI:        https://github.com/spacedmonkey/wp-rest-blocks
  * Description:       Add gutenberg blocks data into the post / page endpoints api.
  * Author:            Jonathan Harris
@@ -20,6 +20,30 @@ use WP_REST_Blocks\Data;
 
 if ( is_readable( __DIR__ . '/vendor/autoload.php' ) ) {
 	require_once __DIR__ . '/vendor/autoload.php';
+}
+
+if ( ! class_exists( '\pQuery' ) ) {
+	/**
+	 * Displays an admin notice about why the plugin is unable to load.
+	 *
+	 * @return void
+	 */
+	function admin_notice() {
+		$message = sprintf(
+			/* translators: %s: build commands. */
+			__( ' Please run %s to finish installation.', 'wp-rest-blocks' ),
+			'<code>composer install</code>'
+		);
+		?>
+		<div class="notice notice-error">
+			<p><strong><?php esc_html_e( 'REST API Blocks plugin could not be initialized.', 'wp-rest-blocks' ); ?></strong></p>
+			<p><?php echo wp_kses( $message, [ 'code' => [] ] ); ?></p>
+		</div>
+		<?php
+	}
+	add_action( 'admin_notices', __NAMESPACE__ . '\admin_notice' );
+
+	return;
 }
 
 require_once __DIR__ . '/src/blocks.php';


### PR DESCRIPTION
After `pQuery` became required, lets make error handling a little cleaner. 