### PR TITLE
Remove PHP platform requirement

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,9 +20,6 @@
   },
   "config": {
     "discard-changes": true,
-    "platform": {
-      "php": "7.0"
-    },
     "sort-packages": true,
     "allow-plugins": {
       "dealerdirect/phpcodesniffer-composer-installer": true,


### PR DESCRIPTION
The plugin works on PHP 8 sites, but cannot be installed (without unwanted workarounds) due to this setting.