### PR TITLE
Add filters to allow modifying the plugin data

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -77,6 +77,14 @@ For example output.
 3. Upload the `wp-rest-blocks` directory to the `/wp-content/plugins/` directory
 4. Activate the plugin in the Plugin dashboard
 
+### Filters
+
+The plugin provides the following filters:
+
+* `rest_api_blocks_get_blocks` - Allows you to modify the block data array
+* `rest_api_blocks_handle_do_block` - Allows you to modify a single block
+* `rest_api_blocks_get_attribute` - Allows you to modify a single block attribute
+
 ## Screenshots
 
 1. Add fields to the rest api.

--- a/src/data.php
+++ b/src/data.php
@@ -29,7 +29,7 @@ function get_blocks( $content, $post_id = 0 ) {
 		}
 	}
 
-	return $output;
+	return apply_filters( 'rest_api_blocks_get_blocks', $output );
 }
 
 /**
@@ -80,7 +80,7 @@ function handle_do_block( array $block, $post_id = 0 ) {
 		}
 	}
 
-	return $block;
+	return apply_filters('rest_api_blocks_handle_do_block', $block);
 }
 
 /**
@@ -144,5 +144,5 @@ function get_attribute( $attribute, $html, $post_id = 0 ) {
 		$value = rest_sanitize_value_from_schema( $value, $attribute );
 	}
 
-	return $value;
+	return apply_filters( 'rest_api_blocks_get_attribute', $value, $attribute, $html, $post_id );
 }


### PR DESCRIPTION
👋 After using the plugin for a headless project I found myself in need to extend the block data. 

For example, I needed to add the image dimensions to a `core/image` block. The width/height isn't present in the `attrs` array unless the user enters it using Gutenberg manually. With the new hook `rest_api_blocks_handle_do_block` you can prefill this data from the WordPress database if the user hasn't overridden it:

```php
add_filter('rest_api_blocks_handle_do_block', function($block) {
    if($block['blockName'] === 'core/image') {
        $metadata = wp_get_attachment_metadata($block['attrs']['id']);

        if(!($block['attrs']['width'] ?? false) && $metadata['width']) {
            $block['attrs']['width'] = $metadata['width'] . 'px';
        }

        if(!($block['attrs']['height'] ?? false) && $metadata['height']) {
            $block['attrs']['height'] = $metadata['height'] . 'px';
        }
    }

    return $block;
});
```

Also added a couple of more hooks for completion.