### PR TITLE
Fix: Don't create pQuery instance unless $attributes['source'] isset.

### DIFF
--- a/src/data.php
+++ b/src/data.php
@@ -94,10 +94,11 @@ function handle_do_block( array $block, $post_id = 0 ) {
  */
 function get_attribute( $attribute, $html, $post_id = 0 ) {
 	$value = null;
-	$dom   = pQuery::parseStr( trim( $html ) );
-	$node  = isset( $attribute['selector'] ) ? $dom->query( $attribute['selector'] ) : $dom->query();
 
 	if ( isset( $attribute['source'] ) ) {
+		$dom   = pQuery::parseStr( trim( $html ) );
+		$node  = isset( $attribute['selector'] ) ? $dom->query( $attribute['selector'] ) : $dom->query();
+		
 		switch ( $attribute['source'] ) {
 			case 'attribute':
 				$value = $node->attr( $attribute['attribute'] );


### PR DESCRIPTION
Right now on each get_attribute call a new instance of pQuery is created, but we don't use it unless the `$attributes['source']` isset.

Moving the instance creation into the if statement should give performance improvements.

Locally is saw a ~50% speed improvement on simple blocks.