### PR TITLE
fix: pQuery deprecated in PHP 8.1

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,10 +13,16 @@
 	"support": {
 		"issues": "https://github.com/spacedmonkey/wp-rest-blocks/issues"
 	},
+	"repositories": [
+		{
+			"type": "vcs",
+			"url": "https://github.com/guyavatrade/pquery"
+		}
+	],
 	"require": {
 		"php": "^7.0 || ^8.0",
 		"composer/installers": "^1.10",
-		"tburry/pquery": "^1.1"
+		"guyavatrade/pquery": "^1.1"
 	},
 	"require-dev": {
 		"phpcompatibility/phpcompatibility-wp": "^2.1",


### PR DESCRIPTION
 Deprecated: Return type of pQuery::offsetExists($offset) should either be compatible with ArrayAccess::offsetExists(mixed $offset): bool, or the #[\ReturnTypeWillChange] attribute should be used to temporarily suppress the notice in /var/www/html/wp-content/plugins/wp-rest-blocks/vendor/tburry/pquery/pQuery.php on line 121
 
 I created a fork for pQuery library and added the missing types. There is no logic change.